### PR TITLE
Added dish and cosangle params to stations

### DIFF
--- a/RemoteTech/RemoteTech_Settings.cfg
+++ b/RemoteTech/RemoteTech_Settings.cfg
@@ -49,6 +49,8 @@
 				ANTENNA
 				{
 					Omni = 1E+06
+					Dish = 0
+					Cosangle = 1
 				}
 			}
         }
@@ -66,6 +68,8 @@
 				ANTENNA
 				{
 					Omni = 1E+06
+					Dish = 0
+					Cosangle = 1
 				}
 			}
         }
@@ -83,6 +87,8 @@
 				ANTENNA
 				{
 					Omni = 9E+06
+					Dish = 0
+					Cosangle = 1
 				}
 			}
         }
@@ -100,6 +106,8 @@
 				ANTENNA
 				{
 					Omni = 9E+06
+					Dish = 0
+					Cosangle = 1
 				}
 			}
         }
@@ -117,6 +125,8 @@
 				ANTENNA
 				{
 					Omni = 9E+06
+					Dish = 0
+					Cosangle = 1
 				}
 			}
         }
@@ -134,6 +144,8 @@
 				ANTENNA
 				{
 					Omni = 9E+06
+					Dish = 0
+					Cosangle = 1
 				}
 			}
         }
@@ -151,6 +163,8 @@
 				ANTENNA
 				{
 					Omni = 1E+06
+					Dish = 0
+					Cosangle = 1
 				}
 			}
         }
@@ -168,6 +182,8 @@
 				ANTENNA
 				{
 					Omni = 9E+06
+					Dish = 0
+					Cosangle = 1
 				}
 			}
         }
@@ -185,6 +201,8 @@
 				ANTENNA
 				{
 					Omni = 9E+06
+					Dish = 0
+					Cosangle = 1
 				}
 			}
         }
@@ -202,6 +220,8 @@
 				ANTENNA
 				{
 					Omni = 1E+06
+					Dish = 0
+					Cosangle = 1
 				}
 			}
         }


### PR DESCRIPTION
After trying the Seti Rebalanced config with required connection for control, I found it wasn't working. Even with the control enabler, I still could not transmit science using the latest Remotetech. After reviewing some other configurations I found some new options in other configs and added them.

This got my configuration working with RT 1.8.2. There are more new options probably worth reviewing.